### PR TITLE
Update EAN13.swift

### DIFF
--- a/Sources/BarcodeView/Models/EAN13.swift
+++ b/Sources/BarcodeView/Models/EAN13.swift
@@ -70,16 +70,18 @@ extension EAN13 {
 
         return digits
     }
-
+    
     private static func verifyChecksumDigit(value: String) -> Bool {
-        let digits = value.map { Int(String($0))! }.dropLast()
-
-        let odd = stride(from: 1, to: digits.count, by: 2).map { digits[$0] }.reduce(0, +) * 3
-        let even = stride(from: 0, to: digits.count, by: 2).map { digits[$0] }.reduce(0, +)
-
-        let calculatedChecksum = 10 - ((odd + even) % 10)
-
-        return String(calculatedChecksum) == value.last.map({ String($0) })
+        let digits = value.compactMap { Int(String($0)) }
+        let lastDigit = digits.last!
+        
+        let evenSum = stride(from: 1, to: digits.count - 1, by: 2).map { digits[$0] }.reduce(0, +) * 3
+        let oddSum = stride(from: 0, to: digits.count - 1, by: 2).map { digits[$0] }.reduce(0, +)
+        let totalSum = evenSum + oddSum
+    
+        let calculatedCheckDigit = totalSum % 10 == 0 ? 0 : 10 - totalSum % 10
+    
+        return calculatedCheckDigit == lastDigit
     }
 }
 


### PR DESCRIPTION
EAN13 calculation corrected - was failing on this one "5903779001320" 

> The digits in even positions are: 9, 3, 7, 0, 1, 2, their sum is 22, multiplied by 3 it is 66;
> The digits in odd positions (except the last one) are: 5, 0, 7, 9, 0, 3, their sum is 24, added to the number above it is 90;
> Dividing 90 by 10 gives us 0 as a remainder;
> It is zero, so just using it as is.